### PR TITLE
feat: Enables captive portal name customization

### DIFF
--- a/firmware/main/apps/wifi/captive/captive_cmd.c
+++ b/firmware/main/apps/wifi/captive/captive_cmd.c
@@ -1,0 +1,46 @@
+#include "captive_cmd.h"
+#include <string.h>
+#include "argtable3/argtable3.h"
+#include "captive_module.h"
+#include "cat_console.h"
+#include "esp_console.h"
+#include "esp_log.h"
+
+static struct {
+  struct arg_str* name;
+  struct arg_end* end;
+} captivecmd_ap_name_args;
+
+static int captivecmd_change_name(int argc, char** argv) {
+  int nerros = arg_parse(argc, argv, (void**) &captivecmd_ap_name_args);
+  if (nerros != 0) {
+    arg_print_errors(stderr, captivecmd_ap_name_args.end, "CAPTIVE_NAME");
+    return 1;
+  }
+
+  if (strlen(captivecmd_ap_name_args.name->sval[0]) > CAPTIVE_PORTAL_MAX_NAME) {
+    printf("Error:  Name must be 100 characters or fewer.\n");
+    return 1;
+  }
+
+  captive_module_change_ap_name(captivecmd_ap_name_args.name->sval[0]);
+
+  return 0;
+}
+
+void captivecmd_register_cmd() {
+  captivecmd_ap_name_args.name =
+      arg_str0(NULL, NULL, "String", "Captive Portal Name");
+  captivecmd_ap_name_args.end = arg_end(1);
+
+  esp_console_cmd_t captivecmd_name = {
+      .command = "captive_name",
+      .category = "captive",
+      .hint = NULL,
+      .help =
+          "Change the name of the Captive Portal Access Point. Name must be "
+          "100 characters or fewer and no spaces.",
+      .func = &captivecmd_change_name,
+      .argtable = &captivecmd_ap_name_args};
+  ESP_ERROR_CHECK(esp_console_cmd_register(&captivecmd_name));
+}

--- a/firmware/main/apps/wifi/captive/captive_cmd.h
+++ b/firmware/main/apps/wifi/captive/captive_cmd.h
@@ -1,0 +1,5 @@
+#ifndef __CAPTIVE_CMD
+#define __CAPTIVE_CMD
+
+void captivecmd_register_cmd();
+#endif

--- a/firmware/main/apps/wifi/captive/captive_module.c
+++ b/firmware/main/apps/wifi/captive/captive_module.c
@@ -166,6 +166,15 @@ static void wifi_init_softap(void) {
              .authmode = WIFI_AUTH_WPA_WPA2_PSK},
   };
 
+  uint8_t esp_mac[6] = {0};
+  esp_read_mac(esp_mac, ESP_MAC_WIFI_STA);
+  char* default_name[20];
+  sprintf(default_name, "%s_%02X:%02X", CONFIG_WIFI_AP_NAME, esp_mac[4],
+          esp_mac[5]);
+  strncpy((char*) wifi_config.ap.ssid, default_name,
+          sizeof(wifi_config.ap.ssid));
+  wifi_config.ap.ssid_len = strlen(default_name);
+
   if (preferences_get_int(CAPTIVE_PORTAL_MODE_FS_KEY, 0) == 1) {
     char* wifi_ssid =
         malloc(strlen((char*) ap_records->records[selected_record].ssid) + 1);
@@ -194,6 +203,7 @@ static void wifi_init_softap(void) {
       strncpy((char*) wifi_config.ap.ssid, wifi_name,
               sizeof(wifi_config.ap.ssid));
       wifi_config.ap.ssid_len = strlen(wifi_name);
+      free(wifi_name);
     }
   }
 

--- a/firmware/main/apps/wifi/captive/captive_module.c
+++ b/firmware/main/apps/wifi/captive/captive_module.c
@@ -36,6 +36,7 @@ static const char* config_dump_menu[] = {"Dump to SD", "No dump"};
 static uint16_t last_index_selected = 0;
 static httpd_handle_t server = NULL;
 static uint16_t retries = 0;
+static char* wifi_ap_name[CAPTIVE_PORTAL_MAX_NAME];
 
 typedef enum {
   PORTALS,
@@ -194,7 +195,6 @@ static void wifi_init_softap(void) {
   esp_err_t err = preferences_get_string(CAPTIVE_PORTAL_FS_NAME, ap_name,
                                          CAPTIVE_PORTAL_MAX_NAME);
   if (err == ESP_OK) {
-    ESP_LOGW("HERE", "New name: %s", ap_name);
     char* wifi_name = malloc(strlen((char*) ap_name + 1));
     if (wifi_name == NULL) {
       ESP_LOGE(TAG, "Failed to allocate memory for wifi_ssid");
@@ -206,6 +206,8 @@ static void wifi_init_softap(void) {
       free(wifi_name);
     }
   }
+
+  strcpy(wifi_ap_name, (char*) wifi_config.ap.ssid);
 
   if (strlen(MININO_CAPTIVE_DEFAULT_PASS) == 0) {
     wifi_config.ap.authmode = WIFI_AUTH_OPEN;
@@ -580,9 +582,9 @@ static void captive_module_show_preference_selector() {
 }
 
 static void captive_module_show_running() {
-  char* body[64];
-  sprintf(body, "Using:%s | Waiting for user creds",
-          (char*) captive_context.portal);
+  char* body[CAPTIVE_PORTAL_MAX_NAME + 84];
+  sprintf(body, "AP Name: %s Using: %s | Waiting for user creds",
+          (char*) wifi_ap_name, (char*) captive_context.portal);
 
   general_notification_ctx_t notification = {0};
   notification.head = "Captive Portal";

--- a/firmware/main/apps/wifi/captive/captive_module.h
+++ b/firmware/main/apps/wifi/captive/captive_module.h
@@ -12,6 +12,8 @@
 #define CAPTIVE_PORTAL_PREF_FS_KEY     "cpprefs"
 #define CAPTIVE_PORTAL_CHANNEL         "cpchan"
 #define CAPTIVE_PORTAL_NET_NAME        "WIFI_AP_DEF"
+#define CAPTIVE_PORTAL_FS_NAME         "cpname"
+#define CAPTIVE_PORTAL_MAX_NAME        100
 
 // USER INputs
 #define CAPTIVE_USER_INPUT1 "user1"
@@ -23,5 +25,6 @@
 #define CAPTIVE_DATA_FILENAME "user_creds.txt"
 
 void captive_module_main(void);
+void captive_module_change_ap_name(char* name);
 
 #endif

--- a/firmware/main/modules/cat_dos/cat_console.c
+++ b/firmware/main/modules/cat_dos/cat_console.c
@@ -33,6 +33,7 @@
 #include "modbus_engine.h"
 #include "modbus_engine_cmd.h"
 
+#include "captive_cmd.h"
 #include "gattcmd_cmd.h"
 #include "hello_cmd.h"
 #include "zb_cli.h"
@@ -176,6 +177,7 @@ static void register_commands() {
   modbus_engine_cmd_register_cmds();
   gattccmd_register_cmd();
   cmd_wifi_list_register_commands();
+  captivecmd_register_cmd();
   // Uncomment to use the demo app commands
   // hello_cmd_register();
 }


### PR DESCRIPTION
Adds functionality to change the captive portal's AP name via a console command.
This allows users to easily customize the network name.
The name is stored in preferences so it persists across reboots.
**Limitations:**
- Only 99 characters
- For now only single words (no spaces)