### PR TITLE
Feat: Localize Spanish Text and translate to english

### DIFF
--- a/firmware/main/apps/ble/hid_device/hid_screens.c
+++ b/firmware/main/apps/ble/hid_device/hid_screens.c
@@ -42,14 +42,14 @@ void hid_module_display_device_information(char* title, char* body) {
 
 void hid_module_display_notify_volumen_up() {
   led_control_run_effect(led_control_pulse_led_right);
-  genera_screen_display_notify_information("Notify", "Volumen Up");
+  genera_screen_display_notify_information("Notify", "Volume Up");
   vTaskDelay(500 / portTICK_PERIOD_MS);
   // general_screen_display_menu(hid_current_item);
 }
 
 void hid_module_display_notify_volumen_down() {
   led_control_run_effect(led_control_pulse_led_left);
-  genera_screen_display_notify_information("Notify", "Volumen Down");
+  genera_screen_display_notify_information("Notify", "Volume Down");
   vTaskDelay(500 / portTICK_PERIOD_MS);
   // general_screen_display_menu(hid_current_item);
 }

--- a/firmware/main/apps/ble/hid_device/hid_screens.h
+++ b/firmware/main/apps/ble/hid_device/hid_screens.h
@@ -24,7 +24,7 @@ enum {
   HID_DEVICE_COUNT
 } hid_device_item = HID_DEVICE_VOL_UP;
 char* hid_device_items[HID_DEVICE_COUNT] = {
-    "Volumen Up", "Volumen Down", "Play",       "Pause",
+    "Volume Up",  "Volume Down", "Play",       "Pause",
     "Stop",       "Mute",         "Next Track", "Previous Track"};
 
 void hid_module_register_menu(menu_tree_t menu);

--- a/firmware/main/apps/ble/trackers/trackers_screens.c
+++ b/firmware/main/apps/ble/trackers/trackers_screens.c
@@ -34,12 +34,12 @@ static const char* distance_label(float d) {
     return "<1m";
   }
   if (d < 5.0f) {
-    return "Cerca";
+    return "Near";
   }
   if (d < 20.0f) {
-    return "Medio";
+    return "Mid";
   }
-  return "Lejos";
+  return "Far";
 }
 
 void trackers_screens_show_status(uint8_t tracker_count,
@@ -71,7 +71,7 @@ void trackers_screens_show_status(uint8_t tracker_count,
     if (last_name != NULL && last_name[0] != '\0') {
       snprintf(buf, sizeof(buf), "Dev:%-11s", last_name);
     } else {
-      snprintf(buf, sizeof(buf), "Dev:(Buscando...)");
+      snprintf(buf, sizeof(buf), "Dev:(Searching)");
     }
     oled_screen_display_text(buf, 0, 2, false);
 
@@ -85,7 +85,7 @@ void trackers_screens_show_status(uint8_t tracker_count,
     if (rssi != 0) {
       snprintf(buf, sizeof(buf), "%4ddBm %s", rssi, rssi_to_bars(rssi));
     } else {
-      snprintf(buf, sizeof(buf), "Sig: Monitoreo");
+      snprintf(buf, sizeof(buf), "Sig: Monitoring");
     }
     oled_screen_display_text(buf, 0, 4, false);
 
@@ -93,7 +93,7 @@ void trackers_screens_show_status(uint8_t tracker_count,
       snprintf(buf, sizeof(buf), "Dst:%5.1fm %s", distance,
                distance_label(distance));
     } else {
-      snprintf(buf, sizeof(buf), "Dst: Sin datos");
+      snprintf(buf, sizeof(buf), "Dst: No data");
     }
     oled_screen_display_text(buf, 0, 5, false);
 
@@ -103,7 +103,7 @@ void trackers_screens_show_status(uint8_t tracker_count,
       snprintf(buf, sizeof(buf), "    %.4f", gps_lon);
       oled_screen_display_text(buf, 0, 7, false);
     } else {
-      snprintf(buf, sizeof(buf), "GPS: Sin fix");
+      snprintf(buf, sizeof(buf), "GPS: No fix");
       oled_screen_display_text(buf, 0, 6, false);
       oled_screen_display_text("^Help vMode", 0, 7, true);
     }
@@ -121,7 +121,7 @@ void trackers_screens_show_status(uint8_t tracker_count,
     if (rssi != 0) {
       snprintf(buf, sizeof(buf), "%4ddBm %s", rssi, rssi_to_bars(rssi));
     } else {
-      snprintf(buf, sizeof(buf), "Sig: Monitoreo");
+      snprintf(buf, sizeof(buf), "Sig: Monitoring");
     }
     oled_screen_display_text(buf, 0, 2, false);
 
@@ -134,21 +134,21 @@ void trackers_screens_show_status(uint8_t tracker_count,
 
 static const char* const HELP_LINES[] = {
     "=== TRACKERS ===",
-    "Detecta AirTag,",
+    "Detects AirTag,",
     "SmartTag, Tile",
-    "y otros rastreadores",
-    "BLE (Bluetooth).",
+    "and other BLE",
+    "trackers.",
     "",
-    "Muestra distancia",
-    "estimada por RSSI.",
+    "Shows estimated",
+    "dist by RSSI.",
     "",
-    "Si GPS activo:",
-    "captura coordenadas",
-    "de cada tracker.",
+    "If GPS active:",
+    "logs tracker",
+    "coordinates.",
     "",
-    "Controles:",
-    "^:Ayuda  v:Scan",
-    "<:Salir",
+    "Controls:",
+    "^:Help   v:Scan",
+    "<:Exit",
 };
 
 void trackers_screens_show_help(uint8_t page) {

--- a/firmware/main/apps/surveillance/surv_sim_screens.c
+++ b/firmware/main/apps/surveillance/surv_sim_screens.c
@@ -39,9 +39,9 @@ void surv_sim_screens_show(const char* mode_name,
     snprintf(buf, sizeof(buf), "Tx:  %-6lu pkts", (unsigned long) packet_count);
     oled_screen_display_text(buf, 0, 4, false);
 
-    oled_screen_display_text("Emision continua", 0, 5, false);
+    oled_screen_display_text("Continuous TX", 0, 5, false);
 
-    oled_screen_display_text("< Salir", 0, 7, true);
+    oled_screen_display_text("< Exit", 0, 7, true);
   } else {
     snprintf(buf, sizeof(buf), "SIM [TX] %-4s %c",
              mode_name ? mode_name : "ALL", spin);
@@ -54,7 +54,7 @@ void surv_sim_screens_show(const char* mode_name,
     snprintf(buf, sizeof(buf), "Tx:%-5lu pkts", (unsigned long) packet_count);
     oled_screen_display_text(buf, 0, 2, false);
 
-    oled_screen_display_text("< Salir", 0, 3, true);
+    oled_screen_display_text("< Exit", 0, 3, true);
   }
 
   oled_screen_display_show();

--- a/firmware/main/apps/surveillance/surveillance_screens.c
+++ b/firmware/main/apps/surveillance/surveillance_screens.c
@@ -79,7 +79,7 @@ void surveillance_screens_show_status(uint8_t score,
     if (last_label != NULL && last_label[0] != '\0') {
       snprintf(buf, sizeof(buf), "Tgt:%-12s", last_label);
     } else {
-      snprintf(buf, sizeof(buf), "Tgt:(Buscando...)");
+      snprintf(buf, sizeof(buf), "Tgt:(Searching)");
     }
     oled_screen_display_text(buf, 0, 2, false);
 
@@ -87,7 +87,7 @@ void surveillance_screens_show_status(uint8_t score,
     if (last_label != NULL && last_label[0] != '\0') {
       snprintf(buf, sizeof(buf), "Trs:%-12s", tier_to_detail(last_tier));
     } else {
-      snprintf(buf, sizeof(buf), "Trs:Sin amenazas");
+      snprintf(buf, sizeof(buf), "Trs:No threats");
     }
     oled_screen_display_text(buf, 0, 3, false);
 
@@ -95,7 +95,7 @@ void surveillance_screens_show_status(uint8_t score,
     if (last_label != NULL && last_label[0] != '\0') {
       snprintf(buf, sizeof(buf), "%4ddBm %s", rssi, rssi_to_bars(rssi));
     } else {
-      snprintf(buf, sizeof(buf), "Sig: Monitoreo");
+      snprintf(buf, sizeof(buf), "Sig: Monitoring");
     }
     oled_screen_display_text(buf, 0, 4, false);
 
@@ -109,7 +109,7 @@ void surveillance_screens_show_status(uint8_t score,
 
     // Pagina 6: Metricas / Buffer
     if (overflows > 0) {
-      snprintf(buf, sizeof(buf), "Cola ovf: %lu", (unsigned long) overflows);
+      snprintf(buf, sizeof(buf), "Queue ovf: %lu", (unsigned long) overflows);
       oled_screen_display_text(buf, 0, 6, false);
     }
 
@@ -126,7 +126,7 @@ void surveillance_screens_show_status(uint8_t score,
     if (last_label != NULL && last_label[0] != '\0') {
       snprintf(buf, sizeof(buf), "Tgt:%-8s T%d", last_label, last_tier);
     } else {
-      snprintf(buf, sizeof(buf), "Tgt: Escaneando");
+      snprintf(buf, sizeof(buf), "Tgt: Scanning");
     }
     oled_screen_display_text(buf, 0, 2, false);
 
@@ -142,22 +142,22 @@ void surveillance_screens_show_status(uint8_t score,
 }
 
 static const char* const HELP_LINES[] = {
-    "=== VIGILANCIA ===",
-    "Detector pasivo de",
-    "camaras y rastreo.",
+    "= SURVEILLANCE =",
+    "Passive cam &",
+    "tracker detect.",
     "",
-    "Flock/ALPR opera",
-    "en EUA y Canada.",
-    "En MX es normal",
-    "ver score 0 CLEAR.",
+    "Flock/ALPR works",
+    "in US & Canada.",
+    "Score 0 CLEAR is",
+    "normal elsewhere",
     "",
-    "Firmas microSD en:",
+    "SD signatures:",
     "surveil/",
     "signatures.csv",
     "",
-    "Controles:",
-    "^:Ayuda  v:Modo",
-    ">:Scan   <:Salir",
+    "Controls:",
+    "^:Help   v:Mode",
+    ">:Scan   <:Exit",
 };
 
 void surveillance_screens_show_help(uint8_t page) {
@@ -173,8 +173,8 @@ void surveillance_screens_show_help(uint8_t page) {
 
 void surveillance_screens_show_radio_busy(void) {
   oled_screen_clear();
-  oled_screen_display_text("! RADIO OCUPADO !", 0, 1, true);
-  oled_screen_display_text("802.15.4 activo", 0, 3, false);
-  oled_screen_display_text("Reinicia Minino", 0, 5, false);
+  oled_screen_display_text("! RADIO BUSY !", 0, 1, true);
+  oled_screen_display_text("802.15.4 active", 0, 3, false);
+  oled_screen_display_text("Restart Minino", 0, 5, false);
   oled_screen_display_show();
 }

--- a/firmware/main/modules/animations_module/animations_module.c
+++ b/firmware/main/modules/animations_module/animations_module.c
@@ -95,7 +95,7 @@ void animations_module_set_pos(uint8_t x, uint8_t y) {
 
 static void task_delay() {
   set_paused(true);
-  vTaskDelay(anim_ctx->animation->duration_ms[anim_ctx->current_frame]);
+  vTaskDelay(pdMS_TO_TICKS(anim_ctx->animation->duration_ms[anim_ctx->current_frame]));
   set_paused(false);
 }
 

--- a/firmware/main/modules/settings/display/screen_saver/screen_saver.c
+++ b/firmware/main/modules/settings/display/screen_saver/screen_saver.c
@@ -11,7 +11,8 @@
 
 static int IDLE_TIMEOUT_S = 30;
 
-static volatile bool screen_saver_running;
+static volatile bool screen_saver_running = false;
+static TaskHandle_t screen_saver_task_handle = NULL;
 static esp_timer_handle_t screen_saver_idle_timer;
 
 void screen_saver_run();
@@ -31,29 +32,37 @@ static void timer_callback() {
   screen_saver_run();
 }
 
-static void show_splash_screen() {
+static void show_splash_screen(void* pvParameters) {
   uint8_t screen_savers_count = sizeof(screen_savers) / sizeof(epd_bitmap_t*);
+  if (screen_savers_count == 0) {
+    screen_saver_running = false;
+    screen_saver_task_handle = NULL;
+    vTaskDelete(NULL);
+    return;
+  }
   int get_logo =
       MIN(screen_savers_count - 1, preferences_get_int("dp_select", 0));
-  const epd_bitmap_t* logo;
-  logo = screen_savers[get_logo];
+  if (get_logo < 0) {
+    get_logo = 0;
+  }
+  const epd_bitmap_t* logo = screen_savers[get_logo];
 
   screen_saver_running = true;
   int w_screen_space = SCREEN_WIDTH2 - logo->width;
   int h_screen_space = SCREEN_HEIGHT2 - logo->height;
-  h_screen_space = h_screen_space == 0 ? 2 : h_screen_space;
+  if (w_screen_space < 0) {
+    w_screen_space = 0;
+  }
+  if (h_screen_space < 0) {
+    h_screen_space = 0;
+  }
+
   int start_x_position = w_screen_space / 2;
-#if CONFIG_RESOLUTION_128X64
-  int start_y_position = 16;
-  int y_direction = 1;
-#else
-  int start_y_position = 0;
-  int y_direction = 0;
-#endif
-  int x_direction = 1;
+  int start_y_position = h_screen_space / 2;
+  int x_direction = (w_screen_space > 0) ? 1 : 0;
+  int y_direction = (h_screen_space > 0) ? 1 : 0;
 
   while (screen_saver_running) {
-    oled_screen_clear_buffer();
     oled_screen_display_bitmap(logo->bitmap, start_x_position, start_y_position,
                                logo->width, logo->height, OLED_DISPLAY_NORMAL);
     oled_screen_display_show();
@@ -61,24 +70,40 @@ static void show_splash_screen() {
     start_x_position += x_direction;
     start_y_position += y_direction;
 
-    if (start_x_position <= 0 || start_x_position >= w_screen_space - 2) {
-      x_direction = -x_direction;
+    if (w_screen_space > 0) {
+      if (start_x_position <= 0) {
+        start_x_position = 0;
+        x_direction = 1;
+      } else if (start_x_position >= w_screen_space) {
+        start_x_position = w_screen_space;
+        x_direction = -1;
+      }
     }
-    if (start_y_position <= 0 || start_y_position >= h_screen_space) {
-      y_direction = -y_direction;
+
+    if (h_screen_space > 0) {
+      if (start_y_position <= 0) {
+        start_y_position = 0;
+        y_direction = 1;
+      } else if (start_y_position >= h_screen_space) {
+        start_y_position = h_screen_space;
+        y_direction = -1;
+      }
     }
-    vTaskDelay(pdMS_TO_TICKS(50));
+
+    vTaskDelay(pdMS_TO_TICKS(10));
   }
 
+  screen_saver_task_handle = NULL;
   vTaskDelete(NULL);
 }
 
 void screen_saver_run() {
-  if (screen_saver_running) {
+  if (screen_saver_running || screen_saver_task_handle != NULL) {
     return;
   }
   oled_screen_clear();
-  xTaskCreate(show_splash_screen, "show_splash_screen", 2048, NULL, 5, NULL);
+  xTaskCreate(show_splash_screen, "show_splash_screen", 2048, NULL, 5,
+              &screen_saver_task_handle);
 }
 
 void screen_saver_stop() {
@@ -87,17 +112,19 @@ void screen_saver_stop() {
 
 void screen_saver_set_idle_timeout(uint8_t timeout_seconds) {
   IDLE_TIMEOUT_S = timeout_seconds;
+  preferences_put_int("dp_time", IDLE_TIMEOUT_S);
 }
 
 bool screen_saver_get_idle_state() {
   bool idle = screen_saver_running;
   screen_saver_stop();
   esp_timer_stop(screen_saver_idle_timer);
-  esp_timer_start_once(screen_saver_idle_timer, IDLE_TIMEOUT_S * 1000 * 1000);
+  esp_timer_start_once(screen_saver_idle_timer, (uint64_t)IDLE_TIMEOUT_S * 1000 * 1000);
   return idle;
 }
 
 void screen_saver_begin() {
+  IDLE_TIMEOUT_S = preferences_get_int("dp_time", 30);
   esp_timer_create_args_t timer_args = {
       .callback = timer_callback, .arg = NULL, .name = "idle_timer"};
   esp_timer_create(&timer_args, &screen_saver_idle_timer);


### PR DESCRIPTION
## Summary
Localize remaining Spanish strings across the UI and translate them to English
for consistency with the rest of the firmware.

## Changes
- Translate Spanish text to English in BLE HID device screens
- Update trackers screens with localized/translated strings
- Localize surveillance screens (real and simulation)
- Fix mixed-language strings in animations module and screen saver
- Touch up screen saver settings strings